### PR TITLE
Add specialist section with determinated date

### DIFF
--- a/src/app/dashboard/collection/species/add/add-specie-dialog.tsx
+++ b/src/app/dashboard/collection/species/add/add-specie-dialog.tsx
@@ -22,6 +22,7 @@ import { z } from "zod";
 import { type Nullable } from "~/types";
 import ImageManager from "~/app/dashboard/shared/components/image-manager";
 import { GeneralInfoForm } from "./components/general-info-form";
+import { SpecialistInfoForm } from "./components/specialist-info-form";
 import { Button } from "~/components/ui/button";
 import { type GetSpecieApiResponse } from "~/app/museu/herbario/types/specie.types";
 import { usePostSpecies, usePutSpecies } from "../api";
@@ -70,6 +71,9 @@ const formSpecieSchema = z.object({
   collectedAt: z.date({
     required_error: "Campo obrigatório",
   }),
+  determinatedAt: z.date({
+    required_error: "Campo obrigatório",
+  }),
   location: z.object({
     lat: z
       .string({ required_error: "Campo obrigatório" })
@@ -90,6 +94,8 @@ const formSpecieSchema = z.object({
   images: z.array(imageSchema, {
     required_error: "Campo obrigatório",
   }),
+  collector: selectSchema,
+  determinator: selectSchema,
   taxonomy: selectSchema,
   characteristics: z.array(selectSchema).optional(),
 });
@@ -128,10 +134,13 @@ export const AddSpecieDialog: React.FC<AddSpecieDialogProps> = ({
       formData.append("location", JSON.stringify(location));
 
       formData.append("collectedAt", values.collectedAt.toISOString());
+      formData.append("determinatedAt", values.determinatedAt.toISOString());
 
       formData.append("scientificName", values.scientificName);
       formData.append("taxonIds", values.taxonomy.value);
       formData.append("description", values.description);
+      formData.append("collectorId", values.collector.value);
+      formData.append("determinatorId", values.determinator.value);
 
       if (values.characteristics?.length) {
         formData.append(
@@ -185,10 +194,13 @@ export const AddSpecieDialog: React.FC<AddSpecieDialogProps> = ({
     form.resetField("commonName");
     form.resetField("scientificName");
     form.resetField("collectedAt");
+    form.resetField("determinatedAt");
     form.resetField("description");
     form.resetField("images");
     form.resetField("characteristics");
     form.resetField("taxonomy");
+    form.resetField("collector");
+    form.resetField("determinator");
     form.resetField("location");
     onClose();
   }
@@ -198,6 +210,7 @@ export const AddSpecieDialog: React.FC<AddSpecieDialogProps> = ({
       form.setValue("commonName", data.commonName);
       form.setValue("scientificName", data.scientificName);
       form.setValue("collectedAt", new Date(data.collectedAt));
+      form.setValue("determinatedAt", new Date(data.determinatedAt));
       form.setValue("description", data.description ?? "");
 
       form.setValue(
@@ -207,6 +220,16 @@ export const AddSpecieDialog: React.FC<AddSpecieDialogProps> = ({
           label: c.name,
         })) ?? [],
       );
+
+      form.setValue("collector", {
+        label: data.collector.name,
+        value: String(data.collector.id),
+      });
+
+      form.setValue("determinator", {
+        label: data.determinator.name,
+        value: String(data.determinator.id),
+      });
 
       if (data.taxons?.length) {
         form.setValue("taxonomy", {
@@ -259,6 +282,7 @@ export const AddSpecieDialog: React.FC<AddSpecieDialogProps> = ({
               <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
                 <div className="flex flex-col gap-4">
                   <GeneralInfoForm isReadOnly={isReadOnly} form={form} />
+                  <SpecialistInfoForm isReadOnly={isReadOnly} form={form} />
                   <CharacteristicInfoForm isReadOnly={isReadOnly} form={form} />
                 </div>
                 <LocationInfoForm isReadOnly={isReadOnly} form={form} />

--- a/src/app/dashboard/collection/species/add/components/specialist-info-form.tsx
+++ b/src/app/dashboard/collection/species/add/components/specialist-info-form.tsx
@@ -1,0 +1,134 @@
+import React from "react";
+import { Controller, type useForm } from "react-hook-form";
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "~/components/ui/form";
+import { AsyncSelect } from "~/components/ui/async-select";
+import { DatePicker } from "~/components/ui/date-picker";
+import { type SpecieFormType } from "../add-specie-dialog";
+import { useGetSpecialists } from "../../api";
+import { useDebouncedInput } from "~/hooks/use-debounced-input";
+
+type SpecialistInfoFormProps = {
+  form: ReturnType<typeof useForm<SpecieFormType>>;
+  isReadOnly?: boolean;
+};
+
+export const SpecialistInfoForm: React.FC<SpecialistInfoFormProps> = ({
+  form,
+  isReadOnly,
+}) => {
+  const collectorInput = useDebouncedInput();
+  const determinatorInput = useDebouncedInput();
+
+  const collectorsQuery = useGetSpecialists({
+    limit: collectorInput.pageLimit,
+    page: collectorInput.curentPage,
+    name: collectorInput.inputValue,
+    type: "collector",
+  });
+
+  const determinatorsQuery = useGetSpecialists({
+    limit: determinatorInput.pageLimit,
+    page: determinatorInput.curentPage,
+    name: determinatorInput.inputValue,
+    type: "determinator",
+  });
+
+  const collectorOptions =
+    collectorsQuery.data?.data?.map((c) => ({
+      label: c.name,
+      value: String(c.id),
+    })) ?? [];
+
+  const determinatorOptions =
+    determinatorsQuery.data?.data?.map((c) => ({
+      label: c.name,
+      value: String(c.id),
+    })) ?? [];
+
+  return (
+    <div className="flex flex-col gap-2">
+      <h2 className="text-lg font-semibold">Especialistas</h2>
+      <FormField
+        control={form.control}
+        name="collector"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Coletor (*)</FormLabel>
+            <FormControl>
+              <Controller
+                name={field.name}
+                control={form.control}
+                render={() => (
+                  <AsyncSelect
+                    name="collector"
+                    control={form.control}
+                    onInputChange={collectorInput.onInputChange}
+                    isLoading={collectorsQuery.isLoading}
+                    options={collectorOptions}
+                    defaultValue={field.value}
+                    isDisabled={isReadOnly}
+                    placeholder="Pesquisar coletor"
+                  />
+                )}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={form.control}
+        name="determinator"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Determinador (*)</FormLabel>
+            <FormControl>
+              <Controller
+                name={field.name}
+                control={form.control}
+                render={() => (
+                  <AsyncSelect
+                    name="determinator"
+                    control={form.control}
+                    onInputChange={determinatorInput.onInputChange}
+                    isLoading={determinatorsQuery.isLoading}
+                    options={determinatorOptions}
+                    defaultValue={field.value}
+                    isDisabled={isReadOnly}
+                    placeholder="Pesquisar determinador"
+                  />
+                )}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={form.control}
+        name="determinatedAt"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Data de Determinação (*)</FormLabel>
+            <FormControl>
+              <DatePicker
+                onChange={field.onChange}
+                value={field.value}
+                isDisabled={isReadOnly}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </div>
+  );
+};

--- a/src/app/dashboard/collection/species/api/index.ts
+++ b/src/app/dashboard/collection/species/api/index.ts
@@ -4,3 +4,4 @@ export * from "./useGetStates";
 export * from "./useGetCities";
 export * from "./useDeleteSpecies";
 export * from "./usePutSpecies";
+export * from "./useGetSpecialists";

--- a/src/app/dashboard/collection/species/api/useGetSpecialists.ts
+++ b/src/app/dashboard/collection/species/api/useGetSpecialists.ts
@@ -1,0 +1,56 @@
+import {
+  type UndefinedInitialDataOptions,
+  useQuery,
+} from "@tanstack/react-query";
+import { type AxiosRequestConfig } from "axios";
+import { type SpecialistApiResponse } from "~/app/museu/herbario/types/specialist.types";
+import { api } from "~/server/api";
+import { type PaginationParams, type WithPagination } from "~/types/pagination";
+
+export type PaginatedGetSpecialistsApiResponse =
+  WithPagination<SpecialistApiResponse>;
+
+export type GetSpecialistsParams = PaginationParams & {
+  name?: string;
+  type?: "collector" | "determinator";
+};
+
+export const GET_SPECIALISTS_QUERY_KEY = "useGetSpecialists";
+
+async function fetchSpecialists(params?: GetSpecialistsParams) {
+  const requestConfig: AxiosRequestConfig = {
+    params: {
+      page: params?.page ?? 1,
+      limit: params?.limit ?? 10,
+      name: params?.name ? params.name : undefined,
+      type: params?.type,
+    },
+  };
+
+  const { data } = await api.get<PaginatedGetSpecialistsApiResponse>(
+    "dashboard/specialists",
+    requestConfig,
+  );
+
+  return data;
+}
+export const getSpecialistsConfig = (
+  params?: GetSpecialistsParams,
+): UndefinedInitialDataOptions<
+  PaginatedGetSpecialistsApiResponse,
+  Error,
+  PaginatedGetSpecialistsApiResponse,
+  string[]
+> => {
+  return {
+    queryKey: [GET_SPECIALISTS_QUERY_KEY, JSON.stringify(params)],
+    queryFn: () => fetchSpecialists(params),
+  };
+};
+
+export function useGetSpecialists(params?: GetSpecialistsParams) {
+  return useQuery({
+    ...getSpecialistsConfig(params),
+    staleTime: 1000 * 60 * 5,
+  });
+}


### PR DESCRIPTION
## Summary
- group collector and determinator into new `Especialistas` section
- add `determinatedAt` field and integrate with dialog logic
- export new specialist section in add specie form

## Testing
- `yarn install`
- `SKIP_ENV_VALIDATION=true yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_68545277642483339242fc6c434c6406