### PR TITLE
Implement password recovery flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,5 @@ yarn-error.log*
 
 # idea files
 .idea
+tmp/
 .vscode

--- a/src/app/confirm-email/api/useConfirmEmail.ts
+++ b/src/app/confirm-email/api/useConfirmEmail.ts
@@ -1,0 +1,10 @@
+import { useMutation } from "@tanstack/react-query";
+import { AuthService } from "~/services/auth.service";
+
+async function confirmEmail(hash: string) {
+  await AuthService.confirmEmail(hash);
+}
+
+export function useConfirmEmail() {
+  return useMutation({ mutationFn: confirmEmail });
+}

--- a/src/app/confirm-email/page.tsx
+++ b/src/app/confirm-email/page.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { CheckCircle2, XCircle } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+import { useEffect } from "react";
+import { useSearchParams } from "next/navigation";
+import { useConfirmEmail } from "./api/useConfirmEmail";
+import { Button } from "~/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "~/components/ui/card";
+import Footer from "../museu/herbario/components/footer";
+
+export default function Page() {
+  const searchParams = useSearchParams();
+  const hash = searchParams.get("hash") ?? "";
+  const confirmEmail = useConfirmEmail();
+
+  useEffect(() => {
+    if (hash) {
+      confirmEmail.mutate(hash);
+    }
+    // run only once when hash changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hash]);
+
+  return (
+    <main className="flex min-h-dvh flex-col justify-between">
+      <header className="bg-[#006633] p-4 text-white">
+        <div className="container mx-auto flex flex-wrap items-center gap-6">
+          <div className="flex items-center gap-4">
+            <Image
+              src="/ufra-logo.png"
+              alt="UFRA Logo"
+              width={100}
+              height={100}
+              className="h-14 w-14 md:h-auto md:w-auto"
+            />
+            <div>
+              <h1 className="text-lg font-bold md:text-3xl">UFRA</h1>
+              <span className="text-sm font-medium">
+                Universidade Federal Rural da Amazônia
+              </span>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <section className="flex items-center justify-center px-2 md:px-0">
+        <Card className="w-full max-w-sm bg-green-50">
+          <CardHeader>
+            <div className="flex items-center space-x-2">
+              {confirmEmail.isError ? (
+                <XCircle className="h-6 w-6 text-red-600" />
+              ) : (
+                <CheckCircle2 className="h-6 w-6 text-green-600" />
+              )}
+              <CardTitle className="text-2xl text-green-800">
+                {confirmEmail.isError ? "Erro" : "Sucesso"}
+              </CardTitle>
+            </div>
+            <CardDescription className="text-green-700">
+              {confirmEmail.isError
+                ? "Não foi possível confirmar seu email."
+                : "Email confirmado com sucesso."}
+            </CardDescription>
+          </CardHeader>
+          <CardContent />
+          <CardFooter>
+            <Link href="/login" passHref className="w-full">
+              <Button className="w-full bg-green-600 text-white hover:bg-green-700">
+                Voltar ao login
+              </Button>
+            </Link>
+          </CardFooter>
+        </Card>
+      </section>
+
+      <Footer />
+    </main>
+  );
+}

--- a/src/app/forgot-password/api/useForgotPassword.ts
+++ b/src/app/forgot-password/api/useForgotPassword.ts
@@ -1,0 +1,12 @@
+import { useMutation } from "@tanstack/react-query";
+import { AuthService } from "~/services/auth.service";
+
+export type ForgotPasswordPayload = { email: string };
+
+async function forgotPassword(payload: ForgotPasswordPayload) {
+  await AuthService.forgotPassword(payload.email);
+}
+
+export function useForgotPassword() {
+  return useMutation({ mutationFn: forgotPassword });
+}

--- a/src/app/forgot-password/confirmation/page.tsx
+++ b/src/app/forgot-password/confirmation/page.tsx
@@ -1,0 +1,64 @@
+import { CheckCircle2 } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+import { Button } from "~/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "~/components/ui/card";
+import Footer from "../../museu/herbario/components/footer";
+
+export default function Page() {
+  return (
+    <main className="flex min-h-dvh flex-col justify-between">
+      <header className="bg-[#006633] p-4 text-white">
+        <div className="container mx-auto flex flex-wrap items-center gap-6">
+          <div className="flex items-center gap-4">
+            <Image
+              src="/ufra-logo.png"
+              alt="UFRA Logo"
+              width={100}
+              height={100}
+              className="h-14 w-14 md:h-auto md:w-auto"
+            />
+            <div>
+              <h1 className="text-lg font-bold md:text-3xl">UFRA</h1>
+              <span className="text-sm font-medium">
+                Universidade Federal Rural da Amazônia
+              </span>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <section className="flex items-center justify-center px-2 md:px-0">
+        <Card className="w-full max-w-sm bg-green-50">
+          <CardHeader>
+            <div className="flex items-center space-x-2">
+              <CheckCircle2 className="h-6 w-6 text-green-600" />
+              <CardTitle className="text-2xl text-green-800">Sucesso</CardTitle>
+            </div>
+            <CardDescription className="text-green-700">
+              Caso o email informado esteja cadastrado, enviaremos instruções para
+              redefinição de senha.
+            </CardDescription>
+          </CardHeader>
+          <CardContent />
+          <CardFooter>
+            <Link href="/login" passHref className="w-full">
+              <Button className="w-full bg-green-600 text-white hover:bg-green-700">
+                Voltar ao login
+              </Button>
+            </Link>
+          </CardFooter>
+        </Card>
+      </section>
+
+      <Footer />
+    </main>
+  );
+}

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -1,7 +1,14 @@
+"use client";
+
 import { Lock } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
-import type React from "react";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { useForgotPassword } from "./api/useForgotPassword";
 import { Button } from "~/components/ui/button";
 import {
   Card,
@@ -16,6 +23,28 @@ import { Label } from "~/components/ui/label";
 import Footer from "../museu/herbario/components/footer";
 
 export default function Page() {
+  const router = useRouter();
+  const forgotPassword = useForgotPassword();
+
+  const schema = z.object({
+    email: z.string().email("Email inválido"),
+  });
+
+  const { register, handleSubmit, formState } = useForm<
+    z.infer<typeof schema>
+  >({
+    resolver: zodResolver(schema),
+  });
+
+  async function onSubmit(values: z.infer<typeof schema>) {
+    try {
+      await forgotPassword.mutateAsync({ email: values.email });
+      router.push("/forgot-password/confirmation");
+    } catch {
+      toast.error("Erro ao solicitar recuperação de senha");
+    }
+  }
+
   return (
     <main className="flex min-h-dvh flex-col justify-between">
       <header className="bg-[#006633] p-4 text-white">
@@ -38,46 +67,50 @@ export default function Page() {
         </div>
       </header>
 
-      <section className="flex items-center justify-center px-2 md:px-0">
-        <Card className="w-full max-w-sm bg-green-50">
-          <CardHeader>
-            <div className="flex items-center space-x-2">
-              <Lock className="h-6 w-6 text-green-600" />
-              <CardTitle className="text-2xl text-green-800">
-                Esqueci minha senha
-              </CardTitle>
-            </div>
-            <CardDescription className="text-green-700">
-              Digite seu email e clique em enviar, você receberá um email com as
-              instruções para redefinir sua senha.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="grid gap-4">
-            <div className="grid gap-2">
-              <Label htmlFor="email" className="text-green-700">
-                Email
-              </Label>
-              <Input
-                id="email"
-                type="email"
-                placeholder="botanist@example.com"
-                required
-                className="border-green-200 focus:border-green-500 focus:ring-green-500"
-              />
-            </div>
-          </CardContent>
-          <CardFooter className="flex flex-col gap-2">
-            <Link style={{ width: "100%" }} href="/dashboard" passHref>
-              <Button className="w-full bg-green-600 text-white hover:bg-green-700">
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <section className="flex items-center justify-center px-2 md:px-0">
+          <Card className="w-full max-w-sm bg-green-50">
+            <CardHeader>
+              <div className="flex items-center space-x-2">
+                <Lock className="h-6 w-6 text-green-600" />
+                <CardTitle className="text-2xl text-green-800">
+                  Esqueci minha senha
+                </CardTitle>
+              </div>
+              <CardDescription className="text-green-700">
+                Digite seu email e clique em enviar, você receberá um email com
+                as instruções para redefinir sua senha.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-4">
+              <div className="grid gap-2">
+                <Label htmlFor="email" className="text-green-700">
+                  Email
+                </Label>
+                <Input
+                  id="email"
+                  type="email"
+                  placeholder="botanist@example.com"
+                  className="border-green-200 focus:border-green-500 focus:ring-green-500"
+                  {...register("email")}
+                />
+              </div>
+            </CardContent>
+            <CardFooter className="flex flex-col gap-2">
+              <Button
+                type="submit"
+                className="w-full bg-green-600 text-white hover:bg-green-700"
+                isLoading={formState.isSubmitting || forgotPassword.isPending}
+              >
                 Enviar
               </Button>
-            </Link>
-            <Link href="/login" className="text-green-600 hover:underline">
-              voltar
-            </Link>
-          </CardFooter>
-        </Card>
-      </section>
+              <Link href="/login" className="text-green-600 hover:underline">
+                voltar
+              </Link>
+            </CardFooter>
+          </Card>
+        </section>
+      </form>
 
       <Footer />
     </main>

--- a/src/app/reset-password/api/useResetPassword.ts
+++ b/src/app/reset-password/api/useResetPassword.ts
@@ -1,0 +1,12 @@
+import { useMutation } from "@tanstack/react-query";
+import { AuthService } from "~/services/auth.service";
+
+export type ResetPasswordPayload = { hash: string; password: string };
+
+async function resetPassword(payload: ResetPasswordPayload) {
+  await AuthService.resetPassword(payload);
+}
+
+export function useResetPassword() {
+  return useMutation({ mutationFn: resetPassword });
+}

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -1,6 +1,14 @@
+"use client";
+
 import { KeyRoundIcon } from "lucide-react";
 import Image from "next/image";
 import type React from "react";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useSearchParams, useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { useResetPassword } from "./api/useResetPassword";
 import { Button } from "~/components/ui/button";
 import {
   Card,
@@ -15,6 +23,38 @@ import { Label } from "~/components/ui/label";
 import Footer from "../museu/herbario/components/footer";
 
 export default function Page() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const hash = searchParams.get("hash") ?? "";
+
+  const schema = z
+    .object({
+      password: z.string().min(8, "Senha muito curta"),
+      passwordConfirmation: z.string().min(8, "Senha muito curta"),
+    })
+    .refine((data) => data.password === data.passwordConfirmation, {
+      message: "As senhas não correspondem",
+      path: ["passwordConfirmation"],
+    });
+
+  const { register, handleSubmit, formState } = useForm<
+    z.infer<typeof schema>
+  >({
+    resolver: zodResolver(schema),
+  });
+
+  const resetPassword = useResetPassword();
+
+  async function onSubmit(values: z.infer<typeof schema>) {
+    try {
+      await resetPassword.mutateAsync({ hash, password: values.password });
+      toast.success("Senha redefinida com sucesso");
+      router.push("/login");
+    } catch {
+      toast.error("Erro ao redefinir senha");
+    }
+  }
+
   return (
     <main className="flex min-h-dvh flex-col justify-between">
       <header className="bg-[#006633] p-4 text-white">
@@ -37,52 +77,58 @@ export default function Page() {
         </div>
       </header>
 
-      <section className="flex items-center justify-center px-2 md:px-0">
-        <Card className="w-full max-w-sm bg-green-50">
-          <CardHeader>
-            <div className="flex items-center space-x-2">
-              <KeyRoundIcon className="h-6 w-6 text-green-600" />
-              <CardTitle className="text-2xl text-green-800">
-                Redefinição de senha
-              </CardTitle>
-            </div>
-            <CardDescription className="text-green-700">
-              Digite sua nova senha e clique em redefinir.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="grid gap-4">
-            <div className="grid gap-2">
-              <Label htmlFor="password" className="text-green-700">
-                Nova Senha
-              </Label>
-              <Input
-                id="password"
-                type="password"
-                placeholder="********"
-                required
-                className="border-green-200 focus:border-green-500 focus:ring-green-500"
-              />
-            </div>
-            <div className="grid gap-2">
-              <Label htmlFor="password" className="text-green-700">
-                Confirmar Senha
-              </Label>
-              <Input
-                id="password"
-                type="password"
-                placeholder="********"
-                required
-                className="border-green-200 focus:border-green-500 focus:ring-green-500"
-              />
-            </div>
-          </CardContent>
-          <CardFooter className="flex flex-col gap-2">
-            <Button className="w-full bg-green-600 text-white hover:bg-green-700">
-              Redefinir
-            </Button>
-          </CardFooter>
-        </Card>
-      </section>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <section className="flex items-center justify-center px-2 md:px-0">
+          <Card className="w-full max-w-sm bg-green-50">
+            <CardHeader>
+              <div className="flex items-center space-x-2">
+                <KeyRoundIcon className="h-6 w-6 text-green-600" />
+                <CardTitle className="text-2xl text-green-800">
+                  Redefinição de senha
+                </CardTitle>
+              </div>
+              <CardDescription className="text-green-700">
+                Digite sua nova senha e clique em redefinir.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-4">
+              <div className="grid gap-2">
+                <Label htmlFor="password" className="text-green-700">
+                  Nova Senha
+                </Label>
+                <Input
+                  id="password"
+                  type="password"
+                  placeholder="********"
+                  className="border-green-200 focus:border-green-500 focus:ring-green-500"
+                  {...register("password")}
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="passwordConfirmation" className="text-green-700">
+                  Confirmar Senha
+                </Label>
+                <Input
+                  id="passwordConfirmation"
+                  type="password"
+                  placeholder="********"
+                  className="border-green-200 focus:border-green-500 focus:ring-green-500"
+                  {...register("passwordConfirmation")}
+                />
+              </div>
+            </CardContent>
+            <CardFooter className="flex flex-col gap-2">
+              <Button
+                type="submit"
+                className="w-full bg-green-600 text-white hover:bg-green-700"
+                isLoading={formState.isSubmitting || resetPassword.isPending}
+              >
+                Redefinir
+              </Button>
+            </CardFooter>
+          </Card>
+        </section>
+      </form>
 
       <Footer />
     </main>

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,5 +1,5 @@
 import { type AuthUser } from "~/interfaces/auth-user.interface";
-import { api } from "~/server/api";
+import { api, publicApi } from "~/server/api";
 
 export interface LoginApiResponse {
   token: string;
@@ -21,5 +21,17 @@ export class AuthService {
     );
 
     return data;
+  }
+
+  static async forgotPassword(email: string) {
+    await publicApi.post("/auth/forgot/password", { email });
+  }
+
+  static async resetPassword(payload: { hash: string; password: string }) {
+    await publicApi.post("/auth/reset/password", payload);
+  }
+
+  static async confirmEmail(hash: string) {
+    await publicApi.post("/auth/confirm/email", { hash });
   }
 }


### PR DESCRIPTION
## Summary
- add API calls for forgot/reset password in AuthService
- hook up mutation helpers for password recovery
- implement forgot password form with API integration
- add confirmation page after requesting password reset
- implement reset password form using reset token
- ignore tmp directory
- add email confirmation page and API call

## Testing
- `SKIP_ENV_VALIDATION=1 yarn lint`
- `SKIP_ENV_VALIDATION=1 yarn build` *(fails: Failed to fetch Open Sans from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6868708f4d08833380cb5d55b8e242e2