### PR TITLE
Add password creation on email confirmation

### DIFF
--- a/src/app/confirm-email/components/set-password-form.tsx
+++ b/src/app/confirm-email/components/set-password-form.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { CheckCircle2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { Button } from "~/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "~/components/ui/card";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { toast } from "sonner";
+import { useResetPassword } from "../../password-change/api/useResetPassword";
+
+type SetPasswordFormProps = {
+  hash: string;
+};
+
+const schema = z
+  .object({
+    password: z.string().min(8, "Senha muito curta"),
+    passwordConfirmation: z.string().min(8, "Senha muito curta"),
+  })
+  .refine((data) => data.password === data.passwordConfirmation, {
+    message: "As senhas não correspondem",
+    path: ["passwordConfirmation"],
+  });
+
+export function SetPasswordForm({ hash }: SetPasswordFormProps) {
+  const router = useRouter();
+  const { register, handleSubmit, formState } = useForm<z.infer<typeof schema>>({
+    resolver: zodResolver(schema),
+  });
+
+  const resetPassword = useResetPassword();
+
+  function onSubmit(values: z.infer<typeof schema>) {
+    resetPassword.mutate(
+      { hash, password: values.password },
+      {
+        onSuccess: () => {
+          toast.success("Senha definida com sucesso");
+          router.push("/login");
+        },
+        onError: () => {
+          toast.error("Erro ao definir senha");
+        },
+      },
+    );
+  }
+
+  return (
+    <section className="flex items-center justify-center px-2 md:px-0">
+      <form onSubmit={handleSubmit(onSubmit)} className="w-full max-w-sm">
+        <Card className="bg-green-50">
+          <CardHeader>
+            <div className="flex items-center space-x-2">
+              <CheckCircle2 className="h-6 w-6 text-green-600" />
+              <CardTitle className="text-2xl text-green-800">Sucesso</CardTitle>
+            </div>
+            <CardDescription className="text-green-700">
+              Email confirmado com sucesso. Defina sua senha abaixo.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="password" className="text-green-700">
+                Senha
+              </Label>
+              <Input
+                id="password"
+                type="password"
+                placeholder="********"
+                required
+                className="border-green-200 focus:border-green-500 focus:ring-green-500"
+                {...register("password")}
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="passwordConfirmation" className="text-green-700">
+                Confirmar Senha
+              </Label>
+              <Input
+                id="passwordConfirmation"
+                type="password"
+                placeholder="********"
+                required
+                className="border-green-200 focus:border-green-500 focus:ring-green-500"
+                {...register("passwordConfirmation")}
+              />
+            </div>
+          </CardContent>
+          <CardFooter className="flex flex-col gap-2">
+            <Button
+              type="submit"
+              className="w-full bg-green-600 text-white hover:bg-green-700"
+              isLoading={formState.isSubmitting || resetPassword.isPending}
+            >
+              Definir senha
+            </Button>
+          </CardFooter>
+        </Card>
+      </form>
+    </section>
+  );
+}
+
+export default SetPasswordForm;

--- a/src/app/confirm-email/page.tsx
+++ b/src/app/confirm-email/page.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/await-thenable */
-import { CheckCircle2, XCircle } from "lucide-react";
+import { XCircle } from "lucide-react";
 import Image from "next/image";
+import SetPasswordForm from "./components/set-password-form";
 import Link from "next/link";
 import { Button } from "~/components/ui/button";
 import {
@@ -71,33 +72,31 @@ export default async function Page({ searchParams }: ConfirmEmailPageProps) {
         </div>
       </header>
 
-      <section className="flex items-center justify-center px-2 md:px-0">
-        <Card className="w-full max-w-sm bg-green-50">
-          <CardHeader>
-            <div className="flex items-center space-x-2">
-              {isError ? (
+      {isError ? (
+        <section className="flex items-center justify-center px-2 md:px-0">
+          <Card className="w-full max-w-sm bg-green-50">
+            <CardHeader>
+              <div className="flex items-center space-x-2">
                 <XCircle className="h-6 w-6 text-red-600" />
-              ) : (
-                <CheckCircle2 className="h-6 w-6 text-green-600" />
-              )}
-              <CardTitle className="text-2xl text-green-800">
-                {isError ? "Erro" : "Sucesso"}
-              </CardTitle>
-            </div>
-            <CardDescription className="text-green-700">
-              {isError ? getErrorMessage() : "Email confirmado com sucesso."}
-            </CardDescription>
-          </CardHeader>
-          <CardContent />
-          <CardFooter>
-            <Link href="/login" passHref className="w-full">
-              <Button className="w-full bg-green-600 text-white hover:bg-green-700">
-                Ir para login
-              </Button>
-            </Link>
-          </CardFooter>
-        </Card>
-      </section>
+                <CardTitle className="text-2xl text-green-800">Erro</CardTitle>
+              </div>
+              <CardDescription className="text-green-700">
+                {getErrorMessage()}
+              </CardDescription>
+            </CardHeader>
+            <CardContent />
+            <CardFooter>
+              <Link href="/login" passHref className="w-full">
+                <Button className="w-full bg-green-600 text-white hover:bg-green-700">
+                  Ir para login
+                </Button>
+              </Link>
+            </CardFooter>
+          </Card>
+        </section>
+      ) : (
+        <SetPasswordForm hash={hash} />
+      )}
 
       <Footer />
     </main>


### PR DESCRIPTION
## Summary
- allow user to set password right after confirming email
- provide SetPasswordForm component with validation

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_687c27ff08688333b6a5ca62c953d8fa