### PR TITLE
Improve herbarium page performance

### DIFF
--- a/src/app/museu/herbario/components/plant-grid.tsx
+++ b/src/app/museu/herbario/components/plant-grid.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Badge } from "~/components/ui/badge";
-import InfiniteScroll from "react-infinite-scroll-component";
+import dynamic from "next/dynamic";
 import { useGetPosts } from "../api";
 import Image from "next/image";
 import defaultImage from "public/default-fallback-image.png";
@@ -11,6 +11,11 @@ import { Skeleton } from "~/components/ui/skeleton";
 import { usePost } from "../context/post-context";
 import LoadingErrorWrapper from "~/components/ui/loading-error-wrapper";
 import { type GetTaxonApiResponse } from "../types/taxonomy.types";
+
+const InfiniteScroll = dynamic(() => import("react-infinite-scroll-component"), {
+  ssr: false,
+  loading: () => <Skeleton className="h-4 w-[250px]" />,
+});
 
 export default function PlantGrid() {
   const { search } = usePost();
@@ -39,7 +44,7 @@ export default function PlantGrid() {
         dataLength={data?.length ?? 0}
       >
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
-          {data?.map((post) => (
+          {data?.map((post, index) => (
             <Link
               href={`/museu/herbario/especie/${encodeURIComponent(post.specie.scientificName.toLowerCase())}`}
               key={post.id}
@@ -53,6 +58,7 @@ export default function PlantGrid() {
                     alt={`image-of-${post.specie.scientificName}`}
                     width={200}
                     height={200}
+                    priority={index === 0}
                     className="h-48 w-full rounded-t-lg object-cover transition-opacity group-hover:opacity-90"
                   />
                 </CardHeader>

--- a/src/app/museu/herbario/components/plant-search.tsx
+++ b/src/app/museu/herbario/components/plant-search.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import dynamic from "next/dynamic";
 import { Input } from "~/components/ui/input";
 import { Button } from "~/components/ui/button";
 import {
@@ -17,11 +18,15 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "~/components/ui/accordion";
-import Select, { type MultiValue } from "react-select";
+import type { MultiValue } from "react-select";
 import { FilterIcon, FilterXIcon } from "lucide-react";
 import { usePost } from "../context/post-context";
 import { useGetCharacteristicFilters, useGetHierarchies } from "../api";
 import { FiltersBadge } from "./filters-badge";
+
+const Select = dynamic(() => import("react-select"), {
+  ssr: false,
+});
 
 export default function PlantSearch() {
   const [accordionValue, setAccordionValue] = useState<string>("");

--- a/src/app/museu/herbario/page.tsx
+++ b/src/app/museu/herbario/page.tsx
@@ -1,7 +1,14 @@
 import getCachedQueryClient from "~/lib/react-query";
 import HerbariumHero from "./components/herbarium-hero";
-import PlantGrid from "./components/plant-grid";
-import PlantSearch from "./components/plant-search";
+import dynamic from "next/dynamic";
+
+const PlantSearch = dynamic(() => import("./components/plant-search"), {
+  loading: () => <div />,
+});
+
+const PlantGrid = dynamic(() => import("./components/plant-grid"), {
+  loading: () => <div />,
+});
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { getCharacteristicFilters, getPostQueryConfig } from "./api";
 import { PostProvider } from "./context/post-context";


### PR DESCRIPTION
## Summary
- dynamically load search and grid sections on herbarium page
- load heavy widgets lazily and prioritize first grid image

## Testing
- `NEXTAUTH_SECRET=placeholder yarn lint`
- `NEXTAUTH_SECRET=placeholder yarn build` *(fails: Failed to fetch `Open Sans` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6893be709920833384ecef8455416c10